### PR TITLE
Fixups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: swift test --package-path sample-coverage-data --enable-code-coverage
-      - uses: vapor/swift-codecov-action@main
+      - uses: vapor/swift-codecov-action@fixups
         with:
           cc_dry_run: true
           cc_flags: unittests
@@ -23,7 +23,7 @@ jobs:
         with: { xcode-version: latest }
       - uses: actions/checkout@v2
       - run: swift test --package-path sample-coverage-data --enable-code-coverage
-      - uses: vapor/swift-codecov-action@main
+      - uses: vapor/swift-codecov-action@fixups
         with:
           cc_dry_run: true
           cc_flags: unittests
@@ -41,7 +41,7 @@ jobs:
         shell: bash
       - run: env
         shell: bash
-      - uses: vapor/swift-codecov-action@main
+      - uses: vapor/swift-codecov-action@fixups
         with:
           cc_dry_run: true
           cc_flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: swift test --package-path sample-coverage-data --enable-code-coverage
-      - uses: vapor/swift-codecov-action@fixups
+      - uses: vapor/swift-codecov-action@main
         with:
           cc_dry_run: true
           cc_flags: unittests
@@ -25,7 +25,7 @@ jobs:
         with: { xcode-version: latest }
       - uses: actions/checkout@v2
       - run: swift test --package-path sample-coverage-data --enable-code-coverage
-      - uses: vapor/swift-codecov-action@fixups
+      - uses: vapor/swift-codecov-action@main
         with:
           cc_dry_run: true
           cc_flags: unittests
@@ -43,7 +43,7 @@ jobs:
         shell: bash
       - run: env
         shell: bash
-      - uses: vapor/swift-codecov-action@fixups
+      - uses: vapor/swift-codecov-action@main
         with:
           cc_dry_run: true
           cc_flags: unittests

--- a/action.yml
+++ b/action.yml
@@ -6,23 +6,19 @@ branding:
 
 inputs:
   ignore_paths:
-    description: A list of regular expressions, one per line, which specify paths in the repository which will not be included in the coverage data. By default, the /.build/ folder is always ignored.
+    description: A regular expression which specifies paths in the repository which will not be included in the coverage data. The /.build folder is always ignored.
     required: false
-    default: /Tests/
+    default: '/Tests/'
   package_path:
     description: The location of the repository. Defaults to $GITHUB_WORKSPACE. This will be used as the working_directory for the Codecov upload action.
     required: false
     # N.B.: Can not simply default to github.workspace here, as it will not be correctly updated when the action is called from
     # within a job which runs in a container.
-    default: 
+    default: ''
   build_parameters:
     description: Additional parameters needed by swift build and swift test to disambiguate the correct target and configuration, i.e. -c release. Only flags which affect the output binary path are required.
     required: false
-    default: 
-  output_path:
-    description: An alternate location to store the result of converting the code coverage data. This is _not_ the same as codecov-action's path_to_write_report.
-    required: false
-    default:
+    default: ''
   # The following are passthrough parameters for the Codecov upload action.
   cc_token:            { description: 'See https://github.com/codecov/codecov-action#arguments', required: false, default: '' }
   cc_flags:            { description: 'See https://github.com/codecov/codecov-action#arguments', required: false, default: '' }
@@ -44,6 +40,7 @@ runs:
       shell: bash
       run: |
         if [[ -n '${{ inputs.package_path }}' ]]; then pkgpath='${{ inputs.package_path }}'; else pkgpath="${GITHUB_WORKSPACE}"; fi
+        pkgpath="$(cd "${pkgpath}" && pwd)"
         
         pkgname="$(swift package --package-path "${pkgpath}" dump-package | \
                    perl -e 'use JSON::PP; print (decode_json(join("",(<>)))->{name});')"
@@ -53,6 +50,7 @@ runs:
         binname="${pkgname}PackageTests.xctest"
         if [[ '${{ runner.os }}' == 'macOS' ]]; then binname+="/Contents/MacOS/${pkgname}PackageTests"; fi
         
+        echo "COVERAGE_ROOT=${pkgpath}" >>"${GITHUB_ENV}"
         echo "COVERAGE_DATA=${covpath}/default.profdata" >>"${GITHUB_ENV}"
         echo "COVERAGE_OBJECT=${binpath}/${binname}" >>"${GITHUB_ENV}"
         echo "COVERAGE_OUTPUT=${covpath}/${pkgname}.lcov" >>"${GITHUB_ENV}"
@@ -78,14 +76,9 @@ runs:
         [[ -n '${{ inputs.cc_verbose }}' ]]          && cc_params+='"verbose": ${{ inputs.cc_verbose }}, '
         [[ -n '${{ inputs.cc_dry_run }}' ]]          && cc_params+='"dry_run": ${{ inputs.cc_dry_run }}, '
                                                         cc_params+='"files": "'"${COVERAGE_OUTPUT}"'"'
+                                                        cc_params+='"root_dir": "'"${COVERAGE_ROOT}"'"'
         echo "CODECOV_ACTION_PARAMS={${cc_params}}" >>"${GITHUB_ENV}"
 
     - id: upload-coverage-report
       uses: codecov/codecov-action@v2
       with: ${{ fromJSON(env.CODECOV_ACTION_PARAMS) }}
-    
-    - id: save-converted-output
-      shell: bash
-      run: |
-        [[ -n '${{ inputs.output_path }}' ]] && cp "${COVERAGE_OUTPUT}" '${{ inputs.output_path }}'
-        echo "::set-output name=output_path::${COVERAGE_OUTPUT}"

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
         [[ -n '${{ inputs.cc_fail_ci_if_error }}' ]] && cc_params+='"fail_ci_if_error": ${{ inputs.cc_fail_ci_if_error }}, '
         [[ -n '${{ inputs.cc_verbose }}' ]]          && cc_params+='"verbose": ${{ inputs.cc_verbose }}, '
         [[ -n '${{ inputs.cc_dry_run }}' ]]          && cc_params+='"dry_run": ${{ inputs.cc_dry_run }}, '
-                                                        cc_params+='"files": "'"${COVERAGE_OUTPUT}"'"'
+                                                        cc_params+='"files": "'"${COVERAGE_OUTPUT}"'", '
                                                         cc_params+='"root_dir": "'"${COVERAGE_ROOT}"'"'
         echo "CODECOV_ACTION_PARAMS={${cc_params}}" >>"${GITHUB_ENV}"
 

--- a/action.yml
+++ b/action.yml
@@ -26,11 +26,6 @@ inputs:
   cc_fail_ci_if_error: { description: 'See https://github.com/codecov/codecov-action#arguments', required: false, default: '' }
   cc_verbose:          { description: 'See https://github.com/codecov/codecov-action#arguments', required: false, default: '' }
   cc_dry_run:          { description: 'See https://github.com/codecov/codecov-action#arguments', required: false, default: '' }
-  
-outputs:
-  codecov_file:
-    description: The absolute path of the converted code coverage data.
-    value: ${{ steps.save-converted-output.outputs.output_path }}
 
 runs:
   using: composite


### PR DESCRIPTION
- Clarify usage of `ignore_paths`.
- Correctly use package path as the root directory for coverage data uploads.
- Canonicalize the package path.
- Remove the `output_path` input and output.