### PR TITLE
Modernize somewhat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,52 +1,60 @@
 name: test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push: { branches: [ 'main' ] }
   workflow_dispatch:
 
 jobs:
   linux-containerized:
+    strategy:
+      fail-fast: false
+      matrix:
+        swift:
+          - swift:5.7-jammy
+          - swift:5.8-jammy
+          - swiftlang/swift:nightly-5.9-jammy
     runs-on: ubuntu-latest
-    container: swift:5.5-focal
+    container: ${{ matrix.swift }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: swift test --package-path sample-coverage-data --enable-code-coverage
-      - uses: vapor/swift-codecov-action@main
+      - uses: vapor/swift-codecov-action@respect-upstream-changes
         with:
           cc_dry_run: true
-          cc_flags: unittests
           cc_env_vars: SWIFT_VERSION,SWIFT_SIGNING_KEY,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH
           cc_verbose: true
           package_path: sample-coverage-data
 
   macos:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with: { xcode-version: latest }
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: swift test --package-path sample-coverage-data --enable-code-coverage
-      - uses: vapor/swift-codecov-action@main
+      - uses: vapor/swift-codecov-action@respect-upstream-changes
         with:
           cc_dry_run: true
-          cc_flags: unittests
           cc_env_vars: MD_APPLE_SDK_ROOT,RUNNER_OS,RUNNER_ARCH
           cc_verbose: true
           package_path: sample-coverage-data
 
   windows:
+    if: ${{ false }}
     runs-on: windows-latest
     steps:
       - uses: compnerd/gha-setup-swift@main
-        with: { branch: 'swift-5.5.1-release', tag: '5.5.1-RELEASE' }
-      - uses: actions/checkout@v2
+        with: { branch: 'swift-5.8-release', tag: '5.8-RELEASE' }
+      - uses: actions/checkout@v3
       - run: swift test --package-path sample-coverage-data --enable-code-coverage
         shell: bash
       - run: env
         shell: bash
-      - uses: vapor/swift-codecov-action@main
+      - uses: vapor/swift-codecov-action@respect-upstream-changes
         with:
           cc_dry_run: true
-          cc_flags: unittests
           cc_env_vars: RUNNER_OS,RUNNER_ARCH
           cc_verbose: true
           package_path: sample-coverage-data

--- a/action.yml
+++ b/action.yml
@@ -34,29 +34,34 @@ runs:
     - id: determine-package-info
       shell: bash
       run: |
-        if [[ -n '${{ inputs.package_path }}' ]]; then pkgpath='${{ inputs.package_path }}'; else pkgpath="${GITHUB_WORKSPACE}"; fi
+        [[ -n '${{ inputs.package_path }}' ]] && pkgpath='${{ inputs.package_path }}' || pkgpath="${GITHUB_WORKSPACE}"
         pkgpath="$(cd "${pkgpath}" && pwd)"
+        echo "COVERAGE_ROOT=${pkgpath}" >>"${GITHUB_ENV}"
         
         pkgname="$(swift package --package-path "${pkgpath}" dump-package | \
                    perl -e 'use JSON::PP; print (decode_json(join("",(<>)))->{name});')"
+
         binpath="$(swift build --package-path "${pkgpath}" ${{ inputs.build_parameters }} --show-bin-path)"
-        covpath="$(dirname "$(swift test --package-path "${pkgpath}" ${{ inputs.build_parameters }} --show-codecov-path)")"
-        
         binname="${pkgname}PackageTests.xctest"
-        if [[ '${{ runner.os }}' == 'macOS' ]]; then binname+="/Contents/MacOS/${pkgname}PackageTests"; fi
-        
-        echo "COVERAGE_ROOT=${pkgpath}" >>"${GITHUB_ENV}"
-        echo "COVERAGE_DATA=${covpath}/default.profdata" >>"${GITHUB_ENV}"
+        [[ "$(uname)" == "Darwin" ]] && binname+="/Contents/macOS/${pkgname}PackageTests"
         echo "COVERAGE_OBJECT=${binpath}/${binname}" >>"${GITHUB_ENV}"
-        echo "COVERAGE_OUTPUT=${covpath}/${pkgname}.lcov" >>"${GITHUB_ENV}"
+
+        # https://github.com/apple/swift-package-manager/issues/5853 - broken by 5.8, fixed in 5.9
+        if [[ "$(swift package tools-version --version)" =~ 5\.8\.[0-9]+$ ]]; then
+            covpath="${binpath}/codecov"
+        else
+            covpath="$(dirname "$(swift test --package-path "${pkgpath}" ${{ inputs.build_parameters }} --show-codecov-path)")"
+        fi
+        echo "COVERAGE_DATA=${covpath}/default.profdata" >>"${GITHUB_ENV}"
+        echo "COVERAGE_OUTPUT=${covpath}/${pkgname}.txt" >>"${GITHUB_ENV}"
 
     - id: convert-coverage-report
       shell: bash
       run: |
-        $(which xcrun || true) llvm-cov export \
-            -format lcov \
+        $(which xcrun || true) llvm-cov show \
+            --format=text \
             --ignore-filename-regex='/\.build/|(${{ inputs.ignore_paths }})' \
-            -instr-profile="${COVERAGE_DATA}" \
+            --instr-profile="${COVERAGE_DATA}" \
             "${COVERAGE_OBJECT}" \
             >"${COVERAGE_OUTPUT}"
 
@@ -71,9 +76,10 @@ runs:
         [[ -n '${{ inputs.cc_verbose }}' ]]          && cc_params+='"verbose": ${{ inputs.cc_verbose }}, '
         [[ -n '${{ inputs.cc_dry_run }}' ]]          && cc_params+='"dry_run": ${{ inputs.cc_dry_run }}, '
                                                         cc_params+='"files": "'"${COVERAGE_OUTPUT}"'", '
+                                                        cc_params+='"functionalities": "search", '
                                                         cc_params+='"root_dir": "'"${COVERAGE_ROOT}"'"'
-        echo "CODECOV_ACTION_PARAMS={${cc_params}}" >>"${GITHUB_ENV}"
+        echo "CODECOV_ACTION_PARAMS={${cc_params}}" >>"${GITHUB_OUTPUT}"
 
     - id: upload-coverage-report
       uses: codecov/codecov-action@v3
-      with: ${{ fromJSON(env.CODECOV_ACTION_PARAMS) }}
+      with: ${{ fromJSON(steps.gather-codecov-params.outputs.CODECOV_ACTION_PARAMS) }}


### PR DESCRIPTION
- Add workaround for apple/swift-package-manager#5853.
- Use `llvm-cov show --format=text` instead of `llvm-cov export --format=lcov`, per the behavior of the Codecov uploader in Swift mode (which still only works for Apple platforms).
- Add `-X search` config for uploader.
- Update testing workflow.
